### PR TITLE
make block a bit bigger

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -77,7 +77,7 @@
     background-color: rgba(255,255,255,0.1);
     width: 13rem;
     min-width: 13rem;
-    height: 5rem;
+    height: 6rem;
 }
 .upcoming > div:nth-child(odd) {
     background-color: rgba(255,255,255,0.17);


### PR DESCRIPTION
Y'a des confs avec des titres très longs qui font apparaitre une scrollbar verticale (sur safari et firefox).

En augmentant un peu la hauteur il n'y a plus de scrollbar nul part.